### PR TITLE
nix: update NixOS-QChem to latest version for newer Gromacs

### DIFF
--- a/nix_files/cpu.nix
+++ b/nix_files/cpu.nix
@@ -2,16 +2,16 @@
 
 let
   nixpkgs = builtins.fetchTarball "https://github.com/NixOS/nixpkgs/archive/25e036ff5d2c9cd9382bbb1bbe0d929950c1449f.tar.gz";
-  overlay = builtins.fetchTarball "https://github.com/markuskowa/NixOS-QChem/archive/b961da2caf815405c4dd40f9ccb4f4e2f8c15bc7.tar.gz";
-  
+  overlay = builtins.fetchTarball "https://github.com/markuskowa/NixOS-QChem/archive/d9c72e7b6c1f63c2a67fc28e94450d0b41e7e793.tar.gz";
+
   pkgs = import nixpkgs {
-    config = { 
+    config = {
       allowUnfree = true;
       qchem-config = {
        optAVX = true;
       };
     };
-    overlays = [ 
+    overlays = [
       (self: super: { cudatoolkit = super.cudatoolkit_11; })
       (import "${overlay}/overlay.nix")
     ];
@@ -24,7 +24,7 @@ in pkgs.mkShell {
   ];
 
   shellHook = ''
-    if [ -z $SLURM_CPUS_PER_TASK ]; then 
+    if [ -z $SLURM_CPUS_PER_TASK ]; then
       export OMP_NUM_THREADS=1
     else
       export OMP_NUM_THREADS=$SLURM_CPUS_PER_TASK

--- a/nix_files/cuda.nix
+++ b/nix_files/cuda.nix
@@ -2,16 +2,16 @@
 
 let
   nixpkgs = builtins.fetchTarball "https://github.com/NixOS/nixpkgs/archive/25e036ff5d2c9cd9382bbb1bbe0d929950c1449f.tar.gz";
-  overlay = builtins.fetchTarball "https://github.com/markuskowa/NixOS-QChem/archive/b961da2caf815405c4dd40f9ccb4f4e2f8c15bc7.tar.gz";
-  
+  overlay = builtins.fetchTarball "https://github.com/markuskowa/NixOS-QChem/archive/d9c72e7b6c1f63c2a67fc28e94450d0b41e7e793.tar.gz";
+
   pkgs = import nixpkgs {
-    config = { 
+    config = {
       allowUnfree = true;
       qchem-config = {
        optAVX = true;
       };
     };
-    overlays = [ 
+    overlays = [
       (self: super: { cudatoolkit = super.cudatoolkit_11; })
       (import "${overlay}/overlay.nix")
     ];
@@ -31,7 +31,7 @@ in pkgs.mkShell {
   shellHook = ''
     export LD_LIBRARY_PATH=$(nixGLNvidia-${nvidiaVersion} printenv LD_LIBRARY_PATH):$LD_LIBRARY_PATH
 
-    if [ -z $SLURM_CPUS_PER_TASK ]; then 
+    if [ -z $SLURM_CPUS_PER_TASK ]; then
       export OMP_NUM_THREADS=1
     else
       export OMP_NUM_THREADS=$SLURM_CPUS_PER_TASK


### PR DESCRIPTION
Give this version a try. It should be faster on the GPUs.
See Gromacs release notes: https://manual.gromacs.org/documentation/current/release-notes/2021/2021.5.html